### PR TITLE
Add `add-cookie` and `delete-all-cookies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - `page-text` returns the textual content of the current page
 - `title` returns the page's title
-- `add-cookie` add a cookie to the browser
-- `delete-all-cookies` clear out the cookie jar
+- `set-cookie!` set a cookie
+- `delete-cookies!` delete a specific cookie
+- `delete-all-cookies!` clear out the cookie jar
 
 ### Changed
 - `fetch!` now calls `str` on its argument, making it compatible with URL types like `java.net.URL` and `lambdaisland.uri.URI`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 - `page-text` returns the textual content of the current page
 - `title` returns the page's title
+- `add-cookie` add a cookie to the browser
+- `delete-all-cookies` clear out the cookie jar
 
 ### Changed
 - `fetch!` now calls `str` on its argument, making it compatible with URL types like `java.net.URL` and `lambdaisland.uri.URI`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A slightly incomplete but fairly idiomatic wrapper
 around
 [jBrowserDriver](https://github.com/MachinePublishers/jBrowserDriver),
-which is a pure-Java [Selenium]()-compatible interface to
+which is a pure-Java [Selenium](http://seleniumhq.org/)-compatible interface to
 the [WebKit](https://webkit.org) browser library included in recent
 JVM versions (>=1.8) as part
 of

--- a/src/sparkledriver/core.clj
+++ b/src/sparkledriver/core.clj
@@ -340,7 +340,7 @@
   (.cacheDir browser))
 
 (defn browser-cookies->map
-  "Convert `browser`'s current cookies into the map format used by clj-http."
+  "Convert `browser`'s current cookies into the map format used by clj-http. This returns cookies from all domains, but cookie names that are set on multiple domains will only be returned once."
   [browser]
   (reduce
    #(assoc %1 (keyword (.getName %2))
@@ -350,12 +350,30 @@
    {}
    (.getCookies (.manage browser))))
 
-(defn delete-all-cookies
-  "Clear all cookies from the browser."
+(defn delete-all-cookies!
+  "Clear all cookies from all domains."
   [browser]
-  (.deleteAllCookies (.manage browser)))
+  (.deleteAllCookies (.manage browser))
+  browser)
 
-(defn- build-selenium-cookie [name value options]
+(defn delete-cookie!
+  "Delete the named cookie from the given domain. When omitted `domain` defaults to the browser's current domain."
+  ([browser name]
+   (delete-cookie! browser name (.getHost (java.net.URL. (current-url browser)))))
+  ([browser name domain]
+   (let [manager (.manage browser)
+         cookies (.getCookies manager)]
+     (when-let [cookie (some (fn [c]
+                               (and (= (.getName c) name)
+                                    (= (.getDomain c) domain)
+                                    c))
+                             cookies)]
+       (.deleteCookie manager cookie))
+     browser)))
+
+(defn- build-selenium-cookie
+  "Build an instance of org.openqa.selenium.Cookie."
+  [name value options]
   (.build
    (reduce
     (fn [builder [k v]]
@@ -369,14 +387,18 @@
     (org.openqa.selenium.Cookie$Builder. name value)
     options)))
 
-(defn add-cookie
-  "Add a cookie with given name and value. Options is a map which can take the following keys:
-  - :domain (String)
-  - :expires-on (java.util.Date)
-  - :http-only (Boolean)
-  - :secure (Boolean)
-  - :path (String)"
-  [browser name value & [options]]
+(defn set-cookie!
+  "Set a cookie with given name and value. If a cookie with the same name and domain is already present, it will be replaced. The following keyword arguments are supported.
+
+  - :domain (String) The cookie domain, defaults to the current domain of the browser.
+  - :expires-on (java.util.Date) Expiration date. Must be in the future or the cookie won't be stored.
+  - :http-only (Boolean) Cookie's HttpOnly flag, disallow access from JavaScript
+  - :secure (Boolean) Cookie's Secure flag, only serve over HTTPS.
+  - :path (String) URL path of the cookie."
+  [browser name value & {domain :domain :as options}]
+  (if domain
+    (delete-cookie! browser name domain)
+    (delete-cookie! browser name))
   (.addCookie (.manage browser) (build-selenium-cookie name value options))
   browser)
 

--- a/src/sparkledriver/core.clj
+++ b/src/sparkledriver/core.clj
@@ -350,6 +350,36 @@
    {}
    (.getCookies (.manage browser))))
 
+(defn delete-all-cookies
+  "Clear all cookies from the browser."
+  [browser]
+  (.deleteAllCookies (.manage browser)))
+
+(defn- build-selenium-cookie [name value options]
+  (.build
+   (reduce
+    (fn [builder [k v]]
+      (case k
+        :domain (.domain builder v)
+        :expires-on (.expiresOn builder v)
+        :http-only (.isHttpOnly builder v)
+        :secure (.isSecure builder v)
+        :path (.path builder v)
+        builder))
+    (org.openqa.selenium.Cookie$Builder. name value)
+    options)))
+
+(defn add-cookie
+  "Add a cookie with given name and value. Options is a map which can take the following keys:
+  - :domain (String)
+  - :expires-on (java.util.Date)
+  - :http-only (Boolean)
+  - :secure (Boolean)
+  - :path (String)"
+  [browser name value & [options]]
+  (.addCookie (.manage browser) (build-selenium-cookie name value options))
+  browser)
+
 (defn page-text
   "Return the complete visible textual content of the current page. Text from hidden elements is not included."
   [browser]

--- a/test/sparkledriver/core_test.clj
+++ b/test/sparkledriver/core_test.clj
@@ -106,7 +106,15 @@
 
     (testing "page helpers"
       (is (= (page-text browser) "Sparkledriver, driven\n\nAnd what rough beast, its hour come round at last\n\nSpiritus Mundi\n\nThe blood-dimmed tide is loosed, and everywhereThe ceremony of innocence is drowned"))
-      (is (= (title browser) "The Second Coming")))))
+      (is (= (title browser) "The Second Coming")))
+
+    (testing "cookies"
+      (add-cookie browser "hello" "SparkleDriver" {:domain "example.com" :path "/home"})
+      (is (= (browser-cookies->map browser)
+             {:hello
+              {:value "SparkleDriver" :domain "example.com" :path "/home"}}))
+      (delete-all-cookies browser)
+      (is (= (browser-cookies->map browser) {})))))
 
 (deftest fetch-test
   (with-browser [browser (make-browser)]

--- a/test/sparkledriver/core_test.clj
+++ b/test/sparkledriver/core_test.clj
@@ -109,12 +109,30 @@
       (is (= (title browser) "The Second Coming")))
 
     (testing "cookies"
-      (add-cookie browser "hello" "SparkleDriver" {:domain "example.com" :path "/home"})
-      (is (= (browser-cookies->map browser)
-             {:hello
-              {:value "SparkleDriver" :domain "example.com" :path "/home"}}))
-      (delete-all-cookies browser)
-      (is (= (browser-cookies->map browser) {})))))
+      (is (= (-> browser
+                 (set-cookie! "no-domain" "uses current domain")
+                 (set-cookie! "no-domain" "can be changed")
+                 (set-cookie! "with-domain" "SparkleDriver" :domain "example.org" :path "/home")
+                 browser-cookies->map)
+             {:no-domain   {:domain "0.0.0.0", :path "/", :value "can be changed"},
+              :with-domain {:domain "example.org", :path "/home", :value "SparkleDriver"}}))
+
+      (is (= (-> browser
+                 delete-all-cookies!
+                 browser-cookies->map) {}))
+
+      (is (= (-> browser
+                 (set-cookie! "a-cookie" "no domain" :path "/foo")
+                 (set-cookie! "a-cookie" "no domain" :path "/bar")
+                 (set-cookie! "a-cookie" "some domain" :domain "example.org")
+                 (set-cookie! "a-cookie" "some domain" :domain "example.org" :http-only true, :secure true, :path "/foo")
+                 (set-cookie! "a-cookie" "some other domain" :domain "clojure.org")
+                 (.. manage getCookies)
+                 (->> (map str))
+                 sort)
+             ["a-cookie=no domain; path=/bar; domain=0.0.0.0"
+              "a-cookie=some domain; path=/foo; domain=example.org;secure;"
+              "a-cookie=some other domain; path=/; domain=clojure.org"])))))
 
 (deftest fetch-test
   (with-browser [browser (make-browser)]


### PR DESCRIPTION
These seemed useful to have. Especially the second one, as I like to reuse a browser instance across tests, but still want to get back to a clean slate. I decided to add `add-cookie` in one go.

I went with an explicit options map instead of keyword args for `add-cookie`. Don't know what your preference is there. It could also be argued that `add-cookie` should follow the format of `browser-cookies->map`. Just let me know if you want anything changed to `add-cookie`. In that case I'll split up the PR so I can get to that later.

If it would be possible to get another release out that would allow me to demonstrate `page-text` and `delete-all-cookies` in the next Lambda Island episode. At your own convenience and only if you're not too busy of course etc. :)

Thanks a lot! All hail to the SparkleDriver.