### PR TITLE
Add script to generate API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 pemfile_cached
 resources
 spider-db
+gh-pages

--- a/generate_docs
+++ b/generate_docs
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Keep a separate branch of generated API docs.
+#
+# This script generates API documentation, commits it to a separate branch, and
+# pushes it upstream. It does this without actually checking out the branch,
+# using a separate working tree directory, so without any disruption to your
+# current working tree. You can have local file modifications, but the git index
+# (staging area) must be clean.
+
+# The git remote to fetch and push to. Also used to find the parent commit.
+TARGET_REMOTE="origin"
+
+# Branch name to commit and push to
+TARGET_BRANCH="gh-pages"
+
+# Command that generates the API docs
+DOC_CMD="lein codox"
+
+# Working tree directory. The output of $DOC_CMD must end up in this directory.
+WORK_TREE="gh-pages"
+
+if ! git diff-index --quiet --cached HEAD ; then
+    echo "Git index isn't clean. Make sure you have no staged changes. (try 'git reset .')"
+    exit
+fi
+
+git fetch $TARGET_REMOTE
+rm -rf $WORK_TREE
+mkdir -p $WORK_TREE
+
+echo "Generating docs"
+$DOC_CMD
+
+echo "Adding file to git index"
+git --work-tree=$WORK_TREE add -A
+
+TREE=`git write-tree`
+echo "Created git tree $TREE"
+
+if git show-ref --quiet --verify "refs/remotes/${TARGET_REMOTE}/${TARGET_BRANCH}" ; then
+    PARENT=`git rev-parse ${TARGET_REMOTE}/${TARGET_BRANCH}`
+    echo "Creating commit with parent ${PARENT} ${TARGET_REMOTE}/${TARGET_BRANCH}"
+    COMMIT=`git commit-tree -p $PARENT $TREE -m 'Updating docs'`
+else
+    echo "Creating first commit of the branch"
+    COMMIT=`git commit-tree $TREE -m 'Updating docs'`
+fi
+
+echo "Commit $COMMIT"
+echo "Pushing to $TARGET_BRANCH"
+
+git reset .
+git push $TARGET_REMOTE $COMMIT:refs/heads/$TARGET_BRANCH
+git fetch
+echo
+git log -1 --stat $TARGET_REMOTE/$TARGET_BRANCH

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,10 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.machinepublishers/jbrowserdriver "0.17.9"]]
+  :plugins [[lein-codox "0.10.3"]]
   :profiles {:dev {:dependencies [[org.slf4j/slf4j-simple "1.7.25"]
                                   [http-kit "2.3.0-alpha2"]
                                   [compojure "1.6.0"]
                                   [hiccup "1.0.5"]]}}
+  :codox {:output-path "gh-pages"}
   :deploy-repositories [["releases" :clojars]])


### PR DESCRIPTION
In case this interests you, this is a script I wrote originally for lambdaisland/uri. It automates as much as possible the process of keeping a `gh-pages` branch with API docs up to date.

Basically after every release you run `./generate_docs`, and it'll add to the remote `gh-pages` branch, creating it if it doesn't exist, while messing as little as possible with your current git state. So it doesn't change your current branch, and you can have local modifications without them disappearing.

This is what the result looks like: https://plexus.github.io/sparkledriver/