### PR TITLE
Bump JBrowserDriver to support newer releases of Java 1.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [com.machinepublishers/jbrowserdriver "1.0.1"]
+                 [com.machinepublishers/jbrowserdriver "1.1.1"]
                  [org.clojure/math.numeric-tower "0.0.4"]]
   :profiles {:dev {:dependencies [[org.slf4j/slf4j-simple "1.7.25"]
                                   [http-kit "2.3.0"]


### PR DESCRIPTION
I don't recall exactly which update of Java (8u212 maybe?) broke JBrowser but they've finally patched it. This just bumps the dependency.

Is there a way to set which version of Java is used?